### PR TITLE
Change getName() => getDisplayName() for Bolt ^3.6 compatibility.

### DIFF
--- a/src/CodeHighlightBoltExtension.php
+++ b/src/CodeHighlightBoltExtension.php
@@ -15,7 +15,7 @@ use Bolt\Extension\SimpleExtension;
  */
 class CodeHighlightBoltExtension extends SimpleExtension
 {
-    public function getName()
+    public function getDisplayName()
     {
         return "Code Highlight";
     }


### PR DESCRIPTION
Since Bolt 3.6.0-beta, getName() has not been overrideable. Changing this to getDisplayName() fixes an error and makes this extension Bolt 3.6+ compatible.

See #4 .